### PR TITLE
chore: downgrade axios version in order to improve compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@pmmmwh/react-refresh-webpack-plugin": "0.5.10",
         "@svgr/webpack": "8.0.1",
         "autoprefixer": "10.4.14",
-        "axios": "1.4.0",
+        "axios": "^0.27.2",
         "babel-jest": "27.5.1",
         "babel-loader": "9.1.3",
         "babel-plugin-react-intl": "7.9.4",
@@ -4030,13 +4030,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
       }
     },
     "node_modules/axios/node_modules/form-data": {
@@ -10926,11 +10925,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@pmmmwh/react-refresh-webpack-plugin": "0.5.10",
     "@svgr/webpack": "8.0.1",
     "autoprefixer": "10.4.14",
-    "axios": "1.4.0",
+    "axios": "^0.27.2",
     "babel-jest": "27.5.1",
     "babel-loader": "9.1.3",
     "babel-plugin-react-intl": "7.9.4",


### PR DESCRIPTION
## Description
The target version (open-release/palm.nelp) is  a copy of this [branch ](https://github.com/openedx/frontend-build/tree/ags/2321)which is necessary to use the frontend-platform version that allows to inject css styles, however the target version includes a  the axios 1.4.0 version which is not compatible with the  [axios-mock-adapter](https://www.npmjs.com/package/axios-mock-adapter) library, so when this version is included in packages like frontend-app-learning the axios version is updated and the test starts to fail 

## Before
![image](https://github.com/nelc/frontend-build/assets/36200299/341fe055-b488-4ccf-976c-336b294b72f2)

![image](https://github.com/nelc/frontend-build/assets/36200299/20508532-525c-45b5-a880-507aebccf073)

## After

![image](https://github.com/nelc/frontend-build/assets/36200299/cad9a0cb-3ad3-49d7-9fa2-734df44386d8)
